### PR TITLE
using the delimiter when writing a errors.csv

### DIFF
--- a/CsvCore/Reader/CsvCoreReader.cs
+++ b/CsvCore/Reader/CsvCoreReader.cs
@@ -158,6 +158,7 @@ public class CsvCoreReader : ICsvCoreReader
         var errorFile = Path.GetFileNameWithoutExtension(filePath);
 
         new CsvCoreWriter()
+            .UseDelimiter(char.Parse(delimiter))
             .Write(Path.Combine(errorFolderPath, $"{errorFile}_errors.csv"), validationResults);
 
         return result;

--- a/CsvCore/Writer/CsvCoreWriter.cs
+++ b/CsvCore/Writer/CsvCoreWriter.cs
@@ -32,6 +32,14 @@ public class CsvCoreWriter : ICsvCoreWriter
 
         try
         {
+            // Ensure the directory exists
+            var directory = Path.GetDirectoryName(filePath);
+
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory!);
+            }
+
             using var writer = new StreamWriter(filePath);
             var properties = typeof(T).GetProperties();
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![open issues](https://img.shields.io/github/issues/DotNet2Web/csvcore)](https://github.com/DotNet2Web/csvcore/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
 ![](https://img.shields.io/badge/release%20strategy-githubflow-orange.svg)
-![Static Badge](https://img.shields.io/badge/8.0%2C_9.0-dummy?label=dotnet&color=%235027d5)
+![Static Badge](https://img.shields.io/badge/6.0%2C_8.0%2C_9.0-dummy?label=dotnet&color=%235027d5)
 
 <a href="#about">About</a> •
 <a href="#how-to-use-it">How To Use</a> •


### PR DESCRIPTION
If you specify a delimiter its nice to also have parsed it in the errors.csv file. 

Now if you want to read the  errors file you can use CsvCoreReader.UseDelimiter(<yourcustomdelimiter>).Read<ValidationModel>(errorFilePath);