### PR TITLE
Said bye to the SetErrorPath and merged it with the validate method

### DIFF
--- a/CsvCore.Specs/Features/Reading/ErrorHandling/CsvCoreReaderErrorHandlingSpecs.cs
+++ b/CsvCore.Specs/Features/Reading/ErrorHandling/CsvCoreReaderErrorHandlingSpecs.cs
@@ -18,7 +18,7 @@ public class CsvCoreReaderErrorHandlingSpecs
     private const string CsvExtension = "csv";
 
     [Fact]
-    public void Should_Write_An_ErrorFile_Without_Using_The_SetErrorPath_Method()
+    public void Should_Write_An_ErrorFile_Without_Setting_A_ErrorPath()
     {
         // Arrange
         var csvCoreReader = new CsvCoreReader();
@@ -112,8 +112,7 @@ public class CsvCoreReaderErrorHandlingSpecs
 
         // Act
         var result = csvCoreReader
-            .SetErrorPath(errorLocation)
-            .Validate()
+            .Validate(errorLocation)
             .Read<PersonModel>(filePath).ToList();
 
         // Assert

--- a/CsvCore/Reader/CsvCoreReader.cs
+++ b/CsvCore/Reader/CsvCoreReader.cs
@@ -39,22 +39,6 @@ public class CsvCoreReader : ICsvCoreReader
     }
 
     /// <summary>
-    /// Use this method to set the error path for the validation errors.
-    /// </summary>
-    /// <returns></returns>
-    public CsvCoreReader SetErrorPath(string? errorPath = null)
-    {
-        errorFolderPath = string.IsNullOrEmpty(errorPath) ? Path.Combine(Directory.GetCurrentDirectory(), "Errors") : errorPath;
-
-        if (!Directory.Exists(errorFolderPath))
-        {
-            Directory.CreateDirectory(errorFolderPath);
-        }
-
-        return this;
-    }
-
-    /// <summary>
     /// Use this method to set the date format for DateTime and DateOnly properties.
     /// </summary>
     /// <param name="format"></param>
@@ -69,8 +53,15 @@ public class CsvCoreReader : ICsvCoreReader
     /// Use this method to tell us that the CSV file does not have a header record.
     /// </summary>
     /// <returns></returns>
-    public CsvCoreReader Validate()
+    public CsvCoreReader Validate(string? errorPath = null)
     {
+        errorFolderPath = string.IsNullOrEmpty(errorPath) ? Path.Combine(Directory.GetCurrentDirectory(), "Errors") : errorPath;
+
+        if (!Directory.Exists(errorFolderPath))
+        {
+            Directory.CreateDirectory(errorFolderPath);
+        }
+
         validate = true;
         return this;
     }

--- a/CsvCore/Reader/ICsvCoreReader.cs
+++ b/CsvCore/Reader/ICsvCoreReader.cs
@@ -6,11 +6,9 @@ public interface ICsvCoreReader
 
     CsvCoreReader WithoutHeader();
 
-    CsvCoreReader SetErrorPath(string? errorPath = null);
-
     CsvCoreReader SetDateTimeFormat(string format);
 
-    CsvCoreReader Validate();
+    CsvCoreReader Validate(string? path = null);
 
     IEnumerable<T> Read<T>(string filePath) where T : class;
 }


### PR DESCRIPTION
We changed our vision on the validation part. Now we wont validate the data before we read it into the result. 
But if you want us to validate you can call the Validate method doing that it will generate an error file.

Need to write the error file to another location just tell us .Validate("the_error_destination_path")
